### PR TITLE
T54: Fix Maven repository URLs in dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,10 +2,11 @@ version: 2
 registries:
   maven-google:
     type: "maven-repository"
-    url: "https://maven.google.com/"
+    url: "https://maven.google.com"
+
   maven-central:
     type: "maven-repository"
-    url: "https://repo1.maven.org/maven2/"
+    url: "https://repo.maven.apache.org/maven2"
 
 updates:
   - package-ecosystem: "gradle"


### PR DESCRIPTION
Removed trailing slashes from Maven repository URLs.