### PR TITLE
T54: Update Dependabot configuration to remove registries

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,21 +1,9 @@
 version: 2
-registries:
-  maven-google:
-    type: "maven-repository"
-    url: "https://maven.google.com"
-
-  maven-central:
-    type: "maven-repository"
-    url: "https://repo.maven.apache.org/maven2"
-
 updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
       interval: "monthly"
-    registries:
-      - "maven-google"
-      - "maven-central"
     groups:
       all-gradle-dependencies:
         patterns: ["*"]


### PR DESCRIPTION
Removed Maven registries from Dependabot configuration.