### PR TITLE
[BUG] T104: Provide fall back value in case `toNotificaitonType` method failed

### DIFF
--- a/app/src/main/java/com/gals/prayertimes/repository/local/Converters.kt
+++ b/app/src/main/java/com/gals/prayertimes/repository/local/Converters.kt
@@ -8,5 +8,9 @@ object Converters {
     fun fromNotificationType(value: NotificationType): String = value.name
 
     @TypeConverter
-    fun toNotificationType(value: String): NotificationType = NotificationType.valueOf(value)
+    fun toNotificationType(value: String): NotificationType = try {
+        NotificationType.valueOf(value)
+    } catch (_: IllegalArgumentException) {
+        NotificationType.SILENT
+    }
 }


### PR DESCRIPTION
-Provided with fallback value in case db migration failed or no value was saved in db